### PR TITLE
Improve memory limit management and avoid throwing

### DIFF
--- a/lib/supertree_variants_multitree.hpp
+++ b/lib/supertree_variants_multitree.hpp
@@ -60,7 +60,7 @@ public:
 			auto alternatives = alloc_nodes(bip_it.num_bip());
 			return multitree_impl::make_alternative_array(new_node, alternatives,
 			                                              bip_it.leaves().count());
-		} catch (std::bad_alloc) {
+		} catch (std::bad_alloc&) {
 			return multitree_impl::make_unexplored(new_node,
 			                                       alloc_leaves(bip_it.leaves()));
 		}


### PR DESCRIPTION
We currently only check the memory limits after a potentially large allocation has already been made, and also don't catch `std::bad_alloc` exceptions that can occurr from the same setting.

This adds a memory limit to the multitree storage management that throws `std::bad_alloc` if we exceed the limit, and catches this (together with the potential true `std::bad_alloc` from huge bipartition counts), adding an unexplored node instead.

Fixes #19