### PR TITLE
Coroutine multitree iterator

### DIFF
--- a/include/terraces/errors.hpp
+++ b/include/terraces/errors.hpp
@@ -1,4 +1,3 @@
-
 #ifndef TERRACES_ERRORS_HPP
 #define TERRACES_ERRORS_HPP
 
@@ -68,6 +67,17 @@ class file_open_error : public std::runtime_error {
  */
 class tree_count_overflow_error : public std::overflow_error {
 	using std::overflow_error::overflow_error;
+};
+
+/**
+ * This error is thrown if during a multitree iteration an unexplored node
+ * is encountered, meaning the multitree enumeration was not complete
+ * (most likely due to time or memory limits)
+ */
+class multitree_unexplored_error : public std::runtime_error {
+public:
+	multitree_unexplored_error()
+	        : std::runtime_error{"multitree_iterator hit unexplored node"} {}
 };
 
 } // namespace terraces

--- a/lib/multitree_iterator.cpp
+++ b/lib/multitree_iterator.cpp
@@ -96,8 +96,7 @@ void multitree_iterator::init_subtree(index_t i) {
 		assert(false && "Malformed multitree: Nested alternative_arrays");
 		break;
 	case multitree_node_type::unexplored:
-		assert(false && "Must not use multitree_iterator with unexplored nodes");
-		break;
+		throw multitree_unexplored_error{};
 	}
 }
 
@@ -117,8 +116,7 @@ bool multitree_iterator::next(index_t root) {
 		return next(left) || (next(right) && reset(left)) ||
 		       (choice.has_choices() && choice.next() && (init_subtree(root), true));
 	case multitree_node_type::unexplored: {
-		assert(false && "Must not use multitree_iterator with unexplored nodes");
-		return false;
+		throw multitree_unexplored_error{};
 	}
 	default:
 		assert(false && "Unknown node type in multitree");
@@ -156,8 +154,7 @@ bool multitree_iterator::reset(index_t root) {
 		init_subtree(root);
 		break;
 	case multitree_node_type::unexplored: {
-		assert(false && "Must not use multitree_iterator with unexplored nodes");
-		break;
+		throw multitree_unexplored_error{};
 	}
 	default:
 		assert(false && "Unknown node type in multitree");

--- a/lib/multitree_iterator.cpp
+++ b/lib/multitree_iterator.cpp
@@ -160,13 +160,13 @@ bool multitree_iterator::next_unconstrained(index_t root) {
 	const auto right = cur.rchild();
 	switch (state) {
 	case 0:
-		if (next_unconstrained(left)) {
+		if (m_unconstrained_choices[left].has_choices() && next_unconstrained(left)) {
 			return true;
 		}
 		state = 1;
 		// fall through
 	case 1:
-		if (next_unconstrained(right)) {
+		if (m_unconstrained_choices[right].has_choices() && next_unconstrained(right)) {
 			reset_unconstrained(left);
 			return true;
 		}

--- a/lib/multitree_iterator.cpp
+++ b/lib/multitree_iterator.cpp
@@ -103,22 +103,25 @@ void multitree_iterator::init_subtree(index_t i) {
 #define RETURN(ret)                                                                                \
 	{                                                                                          \
 		auto res = ret;                                                                    \
-		stack.pop();                                                                       \
-		if (stack.empty()) {                                                               \
+		m_stack.pop();                                                                     \
+		if (m_stack.empty()) {                                                             \
 			return res;                                                                \
 		}                                                                                  \
-		stack.top().result = res;                                                          \
+		m_stack.top().result = res;                                                        \
 		break;                                                                             \
 	}
 
-#define CALL(idx, next_state)                                                                      \
+#define YIELD(next_state)                                                                          \
 	{                                                                                          \
-		stack.emplace(idx);                                                                \
 		top.state = next_state;                                                            \
 		break;                                                                             \
 	}                                                                                          \
 	/* fall through */                                                                         \
 	case next_state:
+
+#define CALL(idx, next_state)                                                                      \
+	{ m_stack.emplace(idx); }                                                                  \
+	YIELD(next_state)
 
 bool multitree_iterator::next(index_t root) {
 	auto node = m_tree[root];
@@ -174,16 +177,9 @@ bool multitree_iterator::next_unconstrained(index_t root) {
 	if (!choice.has_choices()) {
 		return false;
 	}
-	struct state_t {
-		index_t root;
-		int state{};
-		bool result{};
-		state_t(index_t root) : root{root} {}
-	};
-	std::stack<state_t> stack;
-	stack.emplace(root);
+	m_stack.emplace(root);
 	while (true) {
-		auto& top = stack.top();
+		auto& top = m_stack.top();
 		const auto idx = top.root;
 		const auto cur = m_tree[idx];
 		auto& choice = m_unconstrained_choices[idx];

--- a/lib/multitree_iterator.cpp
+++ b/lib/multitree_iterator.cpp
@@ -161,7 +161,6 @@ bool multitree_iterator::next(index_t root) {
 		case 0:
 			if (type == multitree_node_type::base_unconstrained) {
 				if (!next_unconstrained(idx)) {
-					m_unconstrained_current = {};
 					RETURN(false);
 				} else {
 					RETURN(true);

--- a/lib/multitree_iterator.cpp
+++ b/lib/multitree_iterator.cpp
@@ -32,37 +32,43 @@ void multitree_iterator::init_subtree(index_t i, multitree_nodes::unconstrained 
 	init_subtree_unconstrained(i);
 }
 
-void multitree_iterator::init_subtree_unconstrained(index_t i) {
-	const auto& bip = m_unconstrained_choices[i];
+void multitree_iterator::init_subtree_unconstrained(index_t root) {
+	auto init_size = m_init_stack.size();
+	m_init_stack.emplace(root);
 	const auto& data = m_unconstrained_current;
-	auto& node = m_tree[i];
-	if (bip.num_leaves() <= 2) {
-		if (bip.num_leaves() == 1) {
-			node.lchild() = none;
-			node.rchild() = none;
-			node.taxon() = data.begin[bip.leftmost_leaf()];
+	while (m_init_stack.size() > init_size) {
+		auto i = m_init_stack.top();
+		m_init_stack.pop();
+		const auto& bip = m_unconstrained_choices[i];
+		auto& node = m_tree[i];
+		if (bip.num_leaves() <= 2) {
+			if (bip.num_leaves() == 1) {
+				node.lchild() = none;
+				node.rchild() = none;
+				node.taxon() = data.begin[bip.leftmost_leaf()];
+			} else {
+				node.lchild() = i + 1;
+				node.rchild() = i + 2;
+				node.taxon() = none;
+				m_tree[i + 1] = {i, none, none, data.begin[bip.leftmost_leaf()]};
+				m_tree[i + 2] = {i, none, none, data.begin[bip.rightmost_leaf()]};
+			}
 		} else {
-			node.lchild() = i + 1;
-			node.rchild() = i + 2;
+			const auto lbip = small_bipartition{bip.left_mask()};
+			const auto rbip = small_bipartition{bip.right_mask()};
+			const auto left = i + 1;
+			const auto right = i + 1 + 2 * lbip.num_leaves() - 1;
+			node.lchild() = left;
+			node.rchild() = right;
 			node.taxon() = none;
-			m_tree[i + 1] = {i, none, none, data.begin[bip.leftmost_leaf()]};
-			m_tree[i + 2] = {i, none, none, data.begin[bip.rightmost_leaf()]};
-		}
-	} else {
-		const auto lbip = small_bipartition{bip.left_mask()};
-		const auto rbip = small_bipartition{bip.right_mask()};
-		const auto left = i + 1;
-		const auto right = i + 1 + 2 * lbip.num_leaves() - 1;
-		node.lchild() = left;
-		node.rchild() = right;
-		node.taxon() = none;
-		m_unconstrained_choices[left] = lbip;
-		m_unconstrained_choices[right] = rbip;
-		m_tree[node.lchild()].parent() = i;
-		m_tree[node.rchild()].parent() = i;
+			m_unconstrained_choices[left] = lbip;
+			m_unconstrained_choices[right] = rbip;
+			m_tree[node.lchild()].parent() = i;
+			m_tree[node.rchild()].parent() = i;
 
-		init_subtree_unconstrained(left);
-		init_subtree_unconstrained(right);
+			m_init_stack.push(left);
+			m_init_stack.push(right);
+		}
 	}
 }
 
@@ -78,26 +84,35 @@ void multitree_iterator::init_subtree(index_t i, multitree_nodes::inner_node inn
 	m_tree[rindex].parent() = i;
 	m_choices[lindex] = {left};
 	m_choices[rindex] = {right};
-	init_subtree(lindex);
-	init_subtree(rindex);
+	m_init_stack.push(lindex);
+	m_init_stack.push(rindex);
 }
 
-void multitree_iterator::init_subtree(index_t i) {
-	const auto mt_node = m_choices[i].current;
-	switch (mt_node->type) {
-	case multitree_node_type::base_single_leaf:
-		return init_subtree(i, mt_node->single_leaf);
-	case multitree_node_type::base_two_leaves:
-		return init_subtree(i, mt_node->two_leaves);
-	case multitree_node_type::base_unconstrained:
-		return init_subtree(i, mt_node->unconstrained);
-	case multitree_node_type::inner_node:
-		return init_subtree(i, mt_node->inner_node);
-	case multitree_node_type::alternative_array:
-		assert(false && "Malformed multitree: Nested alternative_arrays");
-		break;
-	case multitree_node_type::unexplored:
-		throw multitree_unexplored_error{};
+void multitree_iterator::init_subtree(index_t root) {
+	m_init_stack.push(root);
+	while (!m_init_stack.empty()) {
+		auto i = m_init_stack.top();
+		m_init_stack.pop();
+		const auto mt_node = m_choices[i].current;
+		switch (mt_node->type) {
+		case multitree_node_type::base_single_leaf:
+			init_subtree(i, mt_node->single_leaf);
+			break;
+		case multitree_node_type::base_two_leaves:
+			init_subtree(i, mt_node->two_leaves);
+			break;
+		case multitree_node_type::base_unconstrained:
+			init_subtree(i, mt_node->unconstrained);
+			break;
+		case multitree_node_type::inner_node:
+			init_subtree(i, mt_node->inner_node);
+			break;
+		case multitree_node_type::alternative_array:
+			assert(false && "Malformed multitree: Nested alternative_arrays");
+			break;
+		case multitree_node_type::unexplored:
+			throw multitree_unexplored_error{};
+		}
 	}
 }
 

--- a/lib/multitree_iterator.hpp
+++ b/lib/multitree_iterator.hpp
@@ -50,6 +50,13 @@ private:
 	std::vector<multitree_iterator_choicepoint> m_choices;
 	std::vector<small_bipartition> m_unconstrained_choices;
 	multitree_nodes::unconstrained m_unconstrained_current{};
+	struct state_t {
+		index_t root;
+		int state{};
+		bool result{};
+		state_t(index_t root) : root{root} {}
+	};
+	std::stack<state_t> m_stack;
 
 	void init_subtree(index_t subtree_root);
 	void init_subtree(index_t subtree_root, index_t single_leaf);

--- a/lib/multitree_iterator.hpp
+++ b/lib/multitree_iterator.hpp
@@ -54,7 +54,9 @@ private:
 		index_t root;
 		int state{};
 		bool result{};
-		state_t(index_t root) : root{root} {}
+		bool unconstrained{};
+		state_t(index_t root, bool unconstrained)
+		        : root{root}, unconstrained{unconstrained} {}
 	};
 	std::stack<state_t> m_stack;
 

--- a/lib/multitree_iterator.hpp
+++ b/lib/multitree_iterator.hpp
@@ -59,6 +59,7 @@ private:
 		        : root{root}, unconstrained{unconstrained} {}
 	};
 	std::stack<state_t> m_stack;
+	std::stack<index_t> m_init_stack;
 
 	void init_subtree(index_t subtree_root);
 	void init_subtree(index_t subtree_root, index_t single_leaf);

--- a/lib/multitree_iterator.hpp
+++ b/lib/multitree_iterator.hpp
@@ -1,6 +1,8 @@
 #ifndef MULTITREE_ITERATOR_H
 #define MULTITREE_ITERATOR_H
 
+#include <terraces/errors.hpp>
+
 #include "multitree.hpp"
 #include "small_bipartition.hpp"
 
@@ -57,8 +59,8 @@ private:
 
 	bool next(index_t root);
 	bool next_unconstrained(index_t root, multitree_nodes::unconstrained unconstrained);
-	bool reset(index_t root);
-	bool reset_unconstrained(index_t root, multitree_nodes::unconstrained unconstrained);
+	void reset(index_t root);
+	void reset_unconstrained(index_t root, multitree_nodes::unconstrained unconstrained);
 
 public:
 	multitree_iterator(const multitree_node* root);

--- a/lib/multitree_iterator.hpp
+++ b/lib/multitree_iterator.hpp
@@ -49,18 +49,19 @@ private:
 	terraces::tree m_tree;
 	std::vector<multitree_iterator_choicepoint> m_choices;
 	std::vector<small_bipartition> m_unconstrained_choices;
+	multitree_nodes::unconstrained m_unconstrained_current{};
 
 	void init_subtree(index_t subtree_root);
 	void init_subtree(index_t subtree_root, index_t single_leaf);
 	void init_subtree(index_t subtree_root, multitree_nodes::two_leaves two_leaves);
 	void init_subtree(index_t subtree_root, multitree_nodes::inner_node inner);
 	void init_subtree(index_t subtree_root, multitree_nodes::unconstrained unconstrained);
-	void init_subtree_unconstrained(index_t subtree_root, multitree_nodes::unconstrained data);
+	void init_subtree_unconstrained(index_t subtree_root);
 
 	bool next(index_t root);
-	bool next_unconstrained(index_t root, multitree_nodes::unconstrained unconstrained);
+	bool next_unconstrained(index_t root);
 	void reset(index_t root);
-	void reset_unconstrained(index_t root, multitree_nodes::unconstrained unconstrained);
+	void reset_unconstrained(index_t root);
 
 public:
 	multitree_iterator(const multitree_node* root);


### PR DESCRIPTION
Try to reduce the amount of tree traversals necessary for the multitree iterator by saving the state that did not change from previous traversals.

Closes #21