### PR TITLE
Faster multitree iterator

### DIFF
--- a/include/terraces/errors.hpp
+++ b/include/terraces/errors.hpp
@@ -1,4 +1,3 @@
-
 #ifndef TERRACES_ERRORS_HPP
 #define TERRACES_ERRORS_HPP
 
@@ -68,6 +67,17 @@ class file_open_error : public std::runtime_error {
  */
 class tree_count_overflow_error : public std::overflow_error {
 	using std::overflow_error::overflow_error;
+};
+
+/**
+ * This error is thrown if during a multitree iteration an unexplored node
+ * is encountered, meaning the multitree enumeration was not complete
+ * (most likely due to time or memory limits)
+ */
+class multitree_unexplored_error : public std::runtime_error {
+public:
+	multitree_unexplored_error()
+	        : std::runtime_error{"multitree_iterator hit unexplored node"} {}
 };
 
 } // namespace terraces

--- a/lib/multitree_iterator.cpp
+++ b/lib/multitree_iterator.cpp
@@ -96,8 +96,7 @@ void multitree_iterator::init_subtree(index_t i) {
 		assert(false && "Malformed multitree: Nested alternative_arrays");
 		break;
 	case multitree_node_type::unexplored:
-		assert(false && "Must not use multitree_iterator with unexplored nodes");
-		break;
+		throw multitree_unexplored_error{};
 	}
 }
 
@@ -117,8 +116,7 @@ bool multitree_iterator::next(index_t root) {
 		return next(left) || (next(right) && reset(left)) ||
 		       (choice.has_choices() && choice.next() && (init_subtree(root), true));
 	case multitree_node_type::unexplored: {
-		assert(false && "Must not use multitree_iterator with unexplored nodes");
-		return false;
+		throw multitree_unexplored_error{};
 	}
 	default:
 		assert(false && "Unknown node type in multitree");
@@ -156,8 +154,7 @@ bool multitree_iterator::reset(index_t root) {
 		init_subtree(root);
 		break;
 	case multitree_node_type::unexplored: {
-		assert(false && "Must not use multitree_iterator with unexplored nodes");
-		break;
+		throw multitree_unexplored_error{};
 	}
 	default:
 		assert(false && "Unknown node type in multitree");

--- a/lib/multitree_iterator.hpp
+++ b/lib/multitree_iterator.hpp
@@ -1,6 +1,8 @@
 #ifndef MULTITREE_ITERATOR_H
 #define MULTITREE_ITERATOR_H
 
+#include <terraces/errors.hpp>
+
 #include "multitree.hpp"
 #include "small_bipartition.hpp"
 

--- a/lib/multitree_iterator.hpp
+++ b/lib/multitree_iterator.hpp
@@ -49,13 +49,14 @@ private:
 	terraces::tree m_tree;
 	std::vector<multitree_iterator_choicepoint> m_choices;
 	std::vector<small_bipartition> m_unconstrained_choices;
+	std::stack<index_t> m_init_stack;
 
-	void init_subtree(index_t subtree_root);
+	bool init_subtree(index_t subtree_root);
 	void init_subtree(index_t subtree_root, index_t single_leaf);
 	void init_subtree(index_t subtree_root, multitree_nodes::two_leaves two_leaves);
 	void init_subtree(index_t subtree_root, multitree_nodes::inner_node inner);
 	void init_subtree(index_t subtree_root, multitree_nodes::unconstrained unconstrained);
-	void init_subtree_unconstrained(index_t subtree_root, multitree_nodes::unconstrained data);
+	bool init_subtree_unconstrained(index_t subtree_root, multitree_nodes::unconstrained data);
 
 	bool next(index_t root);
 	bool next_unconstrained(index_t root, multitree_nodes::unconstrained unconstrained);


### PR DESCRIPTION
This PR moves the implementation of init_subtree in the multitree iterator to a non-recursive variant, thus reducing the overhead of call-stacks etc.

Closes #21 